### PR TITLE
Fix relative import in __init__.py

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,8 @@
 import pcbnew
-import pcbnew2boardview
 import os
+
+from .pcbnew2boardview import convert
+
 
 class Pcbnew2Boardview(pcbnew.ActionPlugin):
 
@@ -12,7 +14,7 @@ class Pcbnew2Boardview(pcbnew.ActionPlugin):
     def Run(self):
         kicad_pcb = pcbnew.GetBoard()
         with open(kicad_pcb.GetFileName().replace('.kicad_pcb', '.brd'), 'wt') as brd_file:
-            pcbnew2boardview.convert(kicad_pcb, brd_file)
+            convert(kicad_pcb, brd_file)
 
 
 plugin = Pcbnew2Boardview()

--- a/__main__.py
+++ b/__main__.py
@@ -1,0 +1,3 @@
+from .pcbnew2boardview import main
+
+main()


### PR DESCRIPTION
This commit makes it possible to actually use the plugin as a Python module. Previously, Python would try to find `pcbnew2boardview` in the globally installed modules instead of using the local `pcbnew2boardview.py` file.