### PR TITLE
Fix Issue #11 (Mirrored on KiCad v6 and up)

### DIFF
--- a/pcbnew2boardview.py
+++ b/pcbnew2boardview.py
@@ -6,6 +6,7 @@ import argparse
 
 import pcbnew
 
+
 def skip_module(module, tp=False):
     refdes = module.Reference()
     if refdes == "REF**":
@@ -16,9 +17,11 @@ def skip_module(module, tp=False):
         return True
     return False
 
+
 def coord(nanometers):
     milliinches = nanometers * 5 // 127000
     return milliinches
+
 
 def y_coord(maxy, y, flipped):
     # Adjust y-coordinate to start from the bottom of the board and account for flipped components
@@ -29,6 +32,7 @@ def pad_sort_key(name):
         return (0, int(name))
     else:
         return (1, name)
+
 
 def convert(pcb, brd):
     # Board outline
@@ -134,6 +138,7 @@ def convert(pcb, brd):
                           side=1 + flipped))
     brd.write("\n")
 
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -146,5 +151,7 @@ def main():
     args = parser.parse_args()
     convert(pcbnew.LoadBoard(args.kicad_pcb_file), args.brd_file)
 
+
 if __name__ == "__main__":
     main()
+    

--- a/pcbnew2boardview.py
+++ b/pcbnew2boardview.py
@@ -153,5 +153,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
-    
+    main() 

--- a/pcbnew2boardview.py
+++ b/pcbnew2boardview.py
@@ -6,7 +6,6 @@ import argparse
 
 import pcbnew
 
-
 def skip_module(module, tp=False):
     refdes = module.Reference()
     if refdes == "REF**":
@@ -17,24 +16,19 @@ def skip_module(module, tp=False):
         return True
     return False
 
-
 def coord(nanometers):
     milliinches = nanometers * 5 // 127000
     return milliinches
 
-
-def y_coord(obj, maxy, y):
-    if obj.IsFlipped():
-        return coord(maxy - y)
-    else:
-        return coord(y)
+def y_coord(maxy, y, flipped):
+    # Adjust y-coordinate to start from the bottom of the board and account for flipped components
+    return coord(maxy - y) if not flipped else coord(y)
 
 def pad_sort_key(name):
     if re.match(r"^\d+$", name):
         return (0, int(name))
     else:
         return (1, name)
-
 
 def convert(pcb, brd):
     # Board outline
@@ -54,11 +48,11 @@ def convert(pcb, brd):
     for point in outline_points:
         brd.write("{x} {y}\n"
                   .format(x=coord(point.x),
-                          y=coord(point.y)))
+                          y=y_coord(outline_maxy, point.y, False)))
     if outline.IsClosed():
         brd.write("{x} {y}\n"
                   .format(x=coord(outline_points[0].x),
-                          y=coord(outline_points[0].y)))
+                          y=y_coord(outline_maxy, outline_points[0].y, False)))
     brd.write("\n")
 
     # Nets
@@ -85,14 +79,15 @@ def convert(pcb, brd):
     pin_at = 0
     for module in modules:
         module_bbox = module.GetBoundingBox()
+        flipped = module.IsFlipped()
         brd.write("{ref} {x1} {y1} {x2} {y2} {pin} {side}\n"
                   .format(ref=module.Reference().GetText(),
-                          x1 =coord(module_bbox.GetLeft()),
-                          y1 =y_coord(module, outline_maxy, module_bbox.GetTop()),
-                          x2 =coord(module_bbox.GetRight()),
-                          y2 =y_coord(module, outline_maxy, module_bbox.GetBottom()),
+                          x1=coord(module_bbox.GetLeft()),
+                          y1=y_coord(outline_maxy, module_bbox.GetTop(), flipped),
+                          x2=coord(module_bbox.GetRight()),
+                          y2=y_coord(outline_maxy, module_bbox.GetBottom(), flipped),
                           pin=pin_at,
-                          side=1 + module.IsFlipped()))
+                          side=1 + flipped))
         pin_at += module.GetPadCount()
     brd.write("\n")
 
@@ -109,11 +104,12 @@ def convert(pcb, brd):
               .format(count=len(pads)))
     for pad in pads:
         pad_pos = pad.GetPosition()
+        flipped = pad.GetParent().IsFlipped()
         brd.write("{x} {y} {net} {side}\n"
                   .format(x=coord(pad_pos.x),
-                          y=y_coord(pad, outline_maxy, pad_pos.y),
+                          y=y_coord(outline_maxy, pad_pos.y, flipped),
                           net=pad.GetNetCode(),
-                          side=1 + pad.IsFlipped()))
+                          side=1 + flipped))
     brd.write("\n")
 
     # Nails
@@ -129,14 +125,14 @@ def convert(pcb, brd):
               .format(count=len(testpoints)))
     for module, pad in testpoints:
         pad_pos = pad.GetPosition()
+        flipped = pad.GetParent().IsFlipped()
         brd.write("{probe} {x} {y} {net} {side}\n"
                   .format(probe=module.GetReference()[2:],
                           x=coord(pad_pos.x),
-                          y=y_coord(pad, outline_maxy, pad_pos.y),
+                          y=y_coord(outline_maxy, pad_pos.y, flipped),
                           net=pad.GetNetCode(),
-                          side=1 + pad.IsFlipped()))
+                          side=1 + flipped))
     brd.write("\n")
-
 
 def main():
     parser = argparse.ArgumentParser()
@@ -149,7 +145,6 @@ def main():
 
     args = parser.parse_args()
     convert(pcbnew.LoadBoard(args.kicad_pcb_file), args.brd_file)
-
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This is a fix for the boards being mirrored on KiCad v6 and up (tested on KiCad v7.0.10).

Below is the resulting boardview file for [my USB-C Raspberry Pi Pico](https://github.com/sabogalc/project-piCo) with the current code.

![image](https://github.com/whitequark/kicad-boardview/assets/53708281/17a092e8-c9dc-4839-8492-39ce203eb44e)

and this is what it looks like with the code from this pull request.

![image](https://github.com/whitequark/kicad-boardview/assets/53708281/11aaadfd-9a77-4f6a-b9b7-272b646ab4c4)

For reference, here is a photo of the board.
![image](https://github.com/sabogalc/project-piCo/assets/53708281/e1c1a218-cc8b-47e4-8b84-a7cff7ebbea9)
